### PR TITLE
[Server][FEAT] 이메일 인증 API 작성

### DIFF
--- a/server/src/main/java/com/server/ServerApplication.java
+++ b/server/src/main/java/com/server/ServerApplication.java
@@ -2,7 +2,9 @@ package com.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class ServerApplication {
 

--- a/server/src/main/java/com/server/domain/mail/controller/MailController.java
+++ b/server/src/main/java/com/server/domain/mail/controller/MailController.java
@@ -2,14 +2,15 @@ package com.server.domain.mail.controller;
 
 import javax.validation.Valid;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.server.domain.mail.dto.AuthMailCodeDto;
 import com.server.domain.mail.dto.MailDto;
+import com.server.domain.mail.mapper.AuthMailCodeMapper;
 import com.server.domain.mail.service.MailService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,10 +20,17 @@ import lombok.RequiredArgsConstructor;
 @RestController
 public class MailController {
     private final MailService mailService;
+    private final AuthMailCodeMapper authMailCodeMapper;
 
-    @PostMapping("signup")
-    public ResponseEntity<?> postAuthEmail(@Valid @RequestBody MailDto.Post request) {
-        String authCode = mailService.sendMail(request.getEmail());
-        return new ResponseEntity<>(new MailDto.Response(authCode), HttpStatus.OK);
+    @PostMapping("/signup")
+    public ResponseEntity<?> postSendEmail(@Valid @RequestBody MailDto.Post request) {
+        mailService.sendMail(request.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/auth")
+    public ResponseEntity<?> postAuthEmail(@RequestBody AuthMailCodeDto.Post request) {
+        mailService.authenticationMailCode(authMailCodeMapper.authMailCodeDtoPostToAuthMailCode(request));
+        return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/com/server/domain/mail/dto/AuthMailCodeDto.java
+++ b/server/src/main/java/com/server/domain/mail/dto/AuthMailCodeDto.java
@@ -1,0 +1,15 @@
+package com.server.domain.mail.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class AuthMailCodeDto {
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Post {
+        private String authCode;
+        private String email;
+    }
+}

--- a/server/src/main/java/com/server/domain/mail/entity/AuthMailCode.java
+++ b/server/src/main/java/com/server/domain/mail/entity/AuthMailCode.java
@@ -1,0 +1,21 @@
+package com.server.domain.mail.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@RedisHash(value = "authMailCode", timeToLive = 60 * 10)
+public class AuthMailCode {
+    @Id
+    private String id;
+    private String authCode;
+    @Indexed
+    private String email;
+}

--- a/server/src/main/java/com/server/domain/mail/mapper/AuthMailCodeMapper.java
+++ b/server/src/main/java/com/server/domain/mail/mapper/AuthMailCodeMapper.java
@@ -1,0 +1,12 @@
+package com.server.domain.mail.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+import com.server.domain.mail.dto.AuthMailCodeDto;
+import com.server.domain.mail.entity.AuthMailCode;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface AuthMailCodeMapper {
+    AuthMailCode authMailCodeDtoPostToAuthMailCode(AuthMailCodeDto.Post request);
+}

--- a/server/src/main/java/com/server/domain/mail/repository/AuthMailCodeRepository.java
+++ b/server/src/main/java/com/server/domain/mail/repository/AuthMailCodeRepository.java
@@ -1,0 +1,13 @@
+package com.server.domain.mail.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.server.domain.mail.entity.AuthMailCode;
+
+@Repository
+public interface AuthMailCodeRepository extends CrudRepository<AuthMailCode, String> {
+    Optional<AuthMailCode> findByEmail(String email);
+}

--- a/server/src/main/java/com/server/domain/mail/service/AuthMailCodeService.java
+++ b/server/src/main/java/com/server/domain/mail/service/AuthMailCodeService.java
@@ -1,0 +1,28 @@
+package com.server.domain.mail.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.server.domain.mail.entity.AuthMailCode;
+import com.server.domain.mail.repository.AuthMailCodeRepository;
+import com.server.global.exception.CustomException;
+import com.server.global.exception.ExceptionCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class AuthMailCodeService {
+    private final AuthMailCodeRepository authMailCodeRepository;
+
+    public void saveAuthCode(String authCode, String email) {
+        authMailCodeRepository.save(AuthMailCode.builder().authCode(authCode).email(email).build());
+    }
+
+    @Transactional(readOnly = true)
+    public AuthMailCode getAuthMailCodeByEmail(String email) {
+        AuthMailCode authMailCode = authMailCodeRepository.findByEmail(email)
+            .orElseThrow(() -> new CustomException(ExceptionCode.AUTH_MAIL_CODE_NOT_FOUND));
+        return authMailCode;
+    }
+}

--- a/server/src/main/java/com/server/domain/mail/service/MailService.java
+++ b/server/src/main/java/com/server/domain/mail/service/MailService.java
@@ -7,10 +7,12 @@ import javax.mail.internet.MimeMessage;
 
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 
+import com.server.domain.mail.entity.AuthMailCode;
 import com.server.global.exception.CustomException;
 import com.server.global.exception.ExceptionCode;
 
@@ -23,11 +25,13 @@ import lombok.extern.slf4j.Slf4j;
 public class MailService {
     private final JavaMailSender javaMailSender;
     private final SpringTemplateEngine templateEngine;
+    private final AuthMailCodeService authMailCodeService;
 
     /**
      * TODO: 메일이 있는지 검사를 해야할까?? 추후에 생각해보고 리팩토링
      * */
-    public String sendMail(String email) {
+    @Async
+    public void sendMail(String email) {
         String authCode = createCode();
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         try {
@@ -37,7 +41,7 @@ public class MailService {
             mimeMessageHelper.setSubject("[PLIP] 이메일 인증을 위한 인증코드를 발송했습니다.");
             mimeMessageHelper.setText(setContext(authCode), true);
             javaMailSender.send(mimeMessage);
-            return authCode;
+            authMailCodeService.saveAuthCode(authCode, email);
         } catch (MessagingException e) {
             log.info("##" + email + " 메일 보내기 실패!! 에러 메시지: " + e);
             throw new CustomException(ExceptionCode.MAIL_SEND_FAIL);
@@ -56,7 +60,6 @@ public class MailService {
 
         for (int i = 0; i < 8; i++) {
             int index = random.nextInt(4);
-
             switch (index) {
                 case 0:
                     key.append((char)((int)random.nextInt(26) + 97));
@@ -69,5 +72,13 @@ public class MailService {
             }
         }
         return key.toString();
+    }
+
+    public void authenticationMailCode(AuthMailCode userAuthMailCode) {
+        AuthMailCode findAuthCode = authMailCodeService.getAuthMailCodeByEmail(userAuthMailCode.getEmail());
+        if (!findAuthCode.getAuthCode().equals(userAuthMailCode.getAuthCode())) {
+            log.error("### 사용자의 인증 코드와 실제 인증 코드가 일치하지 않습니다.");
+            throw new CustomException(ExceptionCode.AUTH_MAIL_CODE_MISMATCH);
+        }
     }
 }

--- a/server/src/main/java/com/server/global/config/RedisConfig.java
+++ b/server/src/main/java/com/server/global/config/RedisConfig.java
@@ -5,7 +5,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 @Configuration
 public class RedisConfig {
     @Value("${spring.redis.host}")

--- a/server/src/main/java/com/server/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/server/global/exception/ExceptionCode.java
@@ -12,9 +12,11 @@ public enum ExceptionCode {
     UNAUTHORIZED("invalid token Data", 401),
     MEMBER_NOT_FOUND("Member not found", 404),
     EMAIL_EXISTS("Email exists", 409),
+    AUTH_MAIL_CODE_NOT_FOUND("Auth mail code not found", 404),
+    AUTH_MAIL_CODE_MISMATCH("Auth mail code is mismatch", 403),
     NICKNAME_EXISTS("Nickname exists", 409),
     MAIL_SEND_FAIL("Send mail fail", 500);
-  
+
     private String message;
     private int statusCode;
 

--- a/server/src/test/java/com/server/mail/controller/MailControllerTest.java
+++ b/server/src/test/java/com/server/mail/controller/MailControllerTest.java
@@ -24,7 +24,10 @@ import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.google.gson.Gson;
 import com.server.domain.mail.controller.MailController;
+import com.server.domain.mail.dto.AuthMailCodeDto;
 import com.server.domain.mail.dto.MailDto;
+import com.server.domain.mail.entity.AuthMailCode;
+import com.server.domain.mail.mapper.AuthMailCodeMapper;
 import com.server.domain.mail.service.MailService;
 
 @WebMvcTest(MailController.class)
@@ -38,18 +41,19 @@ public class MailControllerTest {
     private Gson gson;
     @MockBean
     private MailService service;
+    @MockBean
+    private AuthMailCodeMapper authMailCodeMapper;
 
     @Test
-    @DisplayName("이메일 인증을 한다.")
-    void authEmail() throws Exception {
+    @DisplayName("사용자에게 이메일로 인증코드를 보낸다.")
+    void sendEmail() throws Exception {
         //given
-        String authCode = "abcd1234";
         MailDto.Post request = MailDto.Post.builder()
             .email("test@naver.com")
             .build();
         String jsonData = gson.toJson(request);
 
-        given(service.sendMail(Mockito.anyString())).willReturn(authCode);
+        doNothing().when(service).sendMail(Mockito.anyString());
         //when
         ResultActions actions =
             mockMvc.perform(
@@ -60,7 +64,45 @@ public class MailControllerTest {
                 )
                 //then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authCode").value(authCode))
+                .andDo(
+                    MockMvcRestDocumentationWrapper.document("이메일 전송 예제",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                            ResourceSnippetParameters.builder()
+                                .description("이메일 전송")
+                                .requestFields(
+                                    fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
+                                )
+                                .build()
+                        )
+                    )
+                );
+    }
+
+    @Test
+    @DisplayName("사용자에게 인증코드를 받아 이메일 인증을 한다.")
+    void authEmail() throws Exception {
+        //given
+        String email = "test@naver.com";
+        String authCode = "12345678";
+        AuthMailCodeDto.Post request = AuthMailCodeDto.Post.builder()
+            .email(email)
+            .authCode(authCode)
+            .build();
+        String jsonData = gson.toJson(request);
+        given(authMailCodeMapper.authMailCodeDtoPostToAuthMailCode(Mockito.any(AuthMailCodeDto.Post.class))).willReturn(
+            AuthMailCode.builder().build());
+        doNothing().when(service).authenticationMailCode(Mockito.any(AuthMailCode.class));
+        //when
+        ResultActions actions =
+            mockMvc.perform(
+                    post(MAIL_DEFULT_URI + "/auth")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonData)
+                )
+                //then
+                .andExpect(status().isOk())
                 .andDo(
                     MockMvcRestDocumentationWrapper.document("이메일 인증 예제",
                         preprocessRequest(prettyPrint()),
@@ -69,9 +111,7 @@ public class MailControllerTest {
                             ResourceSnippetParameters.builder()
                                 .description("이메일 인증")
                                 .requestFields(
-                                    fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
-                                )
-                                .responseFields(
+                                    fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                                     fieldWithPath("authCode").type(JsonFieldType.STRING).description("인증 코드")
                                 )
                                 .build()


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- [Client/Server][FEAT] PR_제목 -->

## 📌 PR 타입 (해당하는 부분에 x 표시 해 주세요.)

- [x] Feature
- [ ] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
<!-- 작업 내용을 작성합니다 -->
- 원래 있던 이메일 인증 API는 이메일 전송 API로 처리
- 사용자가 작성한 인증 코드와 메일로 보낸 인증 코드를 비교하는 이메일 인증 API 작성
- 이메일 전송 시 비동기로 처리
- 테스트 코드 작성 및 API 문서 작성

## 📚 작업 결과 (캡쳐한 사진이 있다면 올려주세요.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🫶 PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [ ] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [ ] Labels, Milestone이 Issue와 동일하게 적용되어 있습니다.
- [ ] Development에 PR 내용과 연결된 Issue를 등록했습니다.
