### PR TITLE
[Server][FEAT] Access Token 재발급 및 리팩토링

### DIFF
--- a/server/src/main/java/com/server/domain/token/controller/TokenController.java
+++ b/server/src/main/java/com/server/domain/token/controller/TokenController.java
@@ -1,0 +1,31 @@
+package com.server.domain.token.controller;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.server.global.auth.jwt.JwtTokenizer;
+import com.server.global.auth.utils.AccessTokenRenewalUtil;
+import com.server.global.auth.utils.Token;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/tokens")
+@RestController
+public class TokenController {
+    private final JwtTokenizer jwtTokenizer;
+    private final AccessTokenRenewalUtil accessTokenRenewalUtil;
+    @GetMapping
+    public ResponseEntity<?> getToken(HttpServletRequest request, HttpServletResponse response){
+        Token token = accessTokenRenewalUtil.renewAccessToken(request);
+        jwtTokenizer.setHeaderAccessToken(response, token.getAccessToken());
+        jwtTokenizer.setHeaderRefreshToken(response, token.getRefreshToken());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/server/src/main/java/com/server/global/auth/error/AuthenticationError.java
+++ b/server/src/main/java/com/server/global/auth/error/AuthenticationError.java
@@ -35,7 +35,7 @@ public class AuthenticationError {
             return exception.getMessage();
         }
         else{
-            return "사용할 수 없는 사용자입니다.";
+            return "권한이 없는 사용자입니다.";
         }
     }
 }

--- a/server/src/main/java/com/server/global/auth/handler/login/MemberAuthenticationEntryPoint.java
+++ b/server/src/main/java/com/server/global/auth/handler/login/MemberAuthenticationEntryPoint.java
@@ -24,6 +24,7 @@ public class MemberAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException authException) throws IOException, ServletException {
+        log.error("### MemberAuthenticationEntryPoint Error!! : " + authException.getMessage());
         AuthenticationError.sendErrorResponse(response, authException);
     }
 }

--- a/server/src/main/java/com/server/global/auth/handler/login/MemberAuthenticationEntryPoint.java
+++ b/server/src/main/java/com/server/global/auth/handler/login/MemberAuthenticationEntryPoint.java
@@ -24,13 +24,6 @@ public class MemberAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException authException) throws IOException, ServletException {
-        Exception exception = (Exception)request.getAttribute("exception");
-        logExceptionMessage(authException, exception);
-        AuthenticationError.sendErrorResponse(response, exception);
-    }
-
-    private void logExceptionMessage(AuthenticationException authException, Exception exception) {
-        String message = exception != null ? exception.getMessage() : authException.getMessage();
-        log.warn("Unauthorized error happened: {}", message);
+        AuthenticationError.sendErrorResponse(response, authException);
     }
 }

--- a/server/src/main/java/com/server/global/auth/handler/logout/MemberLogoutHandler.java
+++ b/server/src/main/java/com/server/global/auth/handler/logout/MemberLogoutHandler.java
@@ -9,24 +9,30 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 
-import com.server.domain.member.entity.Member;
-import com.server.domain.token.entity.RefreshToken;
 import com.server.domain.token.service.RedisUtils;
-import com.server.domain.token.service.RefreshTokenService;
+
 import com.server.global.auth.jwt.JwtTokenizer;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 public class MemberLogoutHandler implements LogoutHandler {
     private final RedisUtils redisUtils;
     private final JwtTokenizer jwtTokenizer;
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-        String accessToken = jwtTokenizer.getHeaderAccessToken(request);
-        String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
-        Date expiration = jwtTokenizer.getClaims(accessToken, base64EncodedSecretKey).getBody().getExpiration();
-        Long now = new Date().getTime();
-        redisUtils.setBlackList(accessToken, "accessToken",expiration.getTime() - now);
+        try{
+            String accessToken = jwtTokenizer.getHeaderAccessToken(request);
+            String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+            Date expiration = jwtTokenizer.getClaims(accessToken, base64EncodedSecretKey).getBody().getExpiration();
+            Long now = new Date().getTime();
+            redisUtils.setBlackList(accessToken, "accessToken",expiration.getTime() - now);
+        }catch (ExpiredJwtException eje){
+            log.error("### 토큰이 만료되었습니다. 그대로 로그아웃합니다.");
+        }
+
     }
 }

--- a/server/src/main/java/com/server/global/auth/userdetails/CustomOAuth2UserService.java
+++ b/server/src/main/java/com/server/global/auth/userdetails/CustomOAuth2UserService.java
@@ -1,40 +1,21 @@
 package com.server.global.auth.userdetails;
 
-import java.util.Optional;
-
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-import com.server.domain.member.entity.Member;
-import com.server.domain.member.mapper.MemberMapper;
-import com.server.domain.member.repository.MemberRepository;
-
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
-    private final MemberRepository memberRepository;
-    private final MemberMapper memberMapper;
-
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         OAuthAttributes attributes = OAuthAttributes.of(registrationId, oAuth2User.getAttributes());
-        validateOAuth2User(attributes);
         return attributes;
-    }
-
-    /**
-     * 기존 회원이 소셜 로그인도 가능하게 해야할까? 지금은 가능하게 해놓은 상태
-     */
-    private void validateOAuth2User(OAuthAttributes attributes) {
-        Optional<Member> optionalMember = memberRepository.findByEmail(attributes.getEmail());
-        optionalMember.orElseGet(
-            () -> memberRepository.save(memberMapper.oauthAttributesToMember(attributes)));
     }
 }

--- a/server/src/main/java/com/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/server/global/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.server.domain.member.mapper.MemberMapper;
 import com.server.domain.member.repository.MemberRepository;
 import com.server.domain.oauth.service.KakaoTokenOauthService;
 import com.server.domain.token.service.RedisUtils;
@@ -45,6 +46,7 @@ public class SecurityConfig {
     private final RedisUtils redisUtils;
     private final OAuth2TokenUtils oAuth2TokenUtils;
     private final KakaoTokenOauthService kakaoTokenOauthService;
+    private final MemberMapper memberMapper;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -69,7 +71,7 @@ public class SecurityConfig {
                 .userService(oAuth2UserService)
                 .and()
                 .successHandler(
-                    new OAuth2SuccessHandler(delegateTokenUtil, memberRepository, jwtTokenizer, oAuth2TokenUtils, kakaoTokenOauthService)))
+                    new OAuth2SuccessHandler(delegateTokenUtil, memberRepository, jwtTokenizer, oAuth2TokenUtils, kakaoTokenOauthService,memberMapper)))
             .apply(customFilterConfigurers())
             .and()
             .authorizeHttpRequests(authorize -> authorize

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -92,8 +92,10 @@ springdoc:
     path: /docs/swagger
   
 kakao:
-    redirect-url: dsadasdassd
-    api-key: dasdasdasdsaasdasdsa
+    redirect-url: ${REDIRECT_URL8000}
+    api-key: ${API_KEY}
+    #redirect-url: dsadasdassd
+    #api-key: dasdasdasdsaasdasdsa
 
 logging:
   level:

--- a/server/src/test/java/com/server/helper/StubData.java
+++ b/server/src/test/java/com/server/helper/StubData.java
@@ -18,6 +18,22 @@ import com.server.global.auth.jwt.JwtTokenizer;
 
 public class StubData {
     public static class MockSecurity {
+
+        public static String getValidRefreshToken(String secretKey) {
+            JwtTokenizer jwtTokenizer = new JwtTokenizer();
+            Map<String, Object> claims = new HashMap<>();
+            String subject = "test token";
+            Calendar calendar = Calendar.getInstance();
+            calendar.add(Calendar.MINUTE, 1);
+            Date expiration = calendar.getTime();
+
+            String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(secretKey);
+
+            String refreshToken = jwtTokenizer.generateRefreshToken(subject, expiration, base64EncodedSecretKey);
+
+            return refreshToken;
+        }
+
         public static String getValidAccessToken(String secretKey) {
             JwtTokenizer jwtTokenizer = new JwtTokenizer();
             Map<String, Object> claims = new HashMap<>();
@@ -25,7 +41,7 @@ public class StubData {
             claims.put("memberId", 1);
             claims.put("roles", List.of("USER"));
 
-            String subject = "test access token";
+            String subject = "test token";
             Calendar calendar = Calendar.getInstance();
             calendar.add(Calendar.MINUTE, 1);
             Date expiration = calendar.getTime();
@@ -44,7 +60,7 @@ public class StubData {
             claims.put("memberId", 1);
             claims.put("roles", List.of("USER"));
 
-            String subject = "test access token123";
+            String subject = "test logout token";
             Calendar calendar = Calendar.getInstance();
             calendar.add(Calendar.MINUTE, 1);
             Date expiration = calendar.getTime();

--- a/server/src/test/java/com/server/token/controller/TokenControllerTest.java
+++ b/server/src/test/java/com/server/token/controller/TokenControllerTest.java
@@ -1,0 +1,81 @@
+package com.server.token.controller;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+
+import com.server.global.auth.jwt.JwtTokenizer;
+import com.server.global.auth.utils.AccessTokenRenewalUtil;
+import com.server.global.auth.utils.Token;
+import com.server.helper.StubData;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TokenControllerTest {
+    private final String TOKEN_DEFULT_URI = "/api/tokens";
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private JwtTokenizer jwtTokenizer;
+    @MockBean
+    AccessTokenRenewalUtil accessTokenRenewalUtil;
+
+    @Test
+    @DisplayName("리프레쉬 토큰으로 엑세스 토큰을 재발급합니다.")
+    void getToken() throws Exception {
+        //given
+        String refreshToken = StubData.MockSecurity.getValidRefreshToken(jwtTokenizer.getSecretKey());
+        String accessToken = StubData.MockSecurity.getValidAccessToken(jwtTokenizer.getSecretKey());
+        Token token = Token.builder()
+            .refreshToken(refreshToken)
+            .refreshToken(accessToken)
+            .build();
+
+        given(accessTokenRenewalUtil.renewAccessToken(Mockito.any(HttpServletRequest.class))).willReturn(token);
+        //when
+        ResultActions actions = mockMvc.perform(
+                get(TOKEN_DEFULT_URI)
+                    .cookie(new Cookie("Refresh", refreshToken))
+                    .contentType(MediaType.APPLICATION_JSON))
+            //then
+            .andExpect(status().isOk())
+            .andDo(
+                MockMvcRestDocumentationWrapper.document("회원 등록 예제",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .description("회원 등록")
+                            .responseHeaders(
+                                headerWithName("Authorization").description("재발급받은 인증 토큰")
+                            )
+                            .build())));
+
+    }
+}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- [Client/Server][FEAT] PR_제목 -->

## 📌 PR 타입 (해당하는 부분에 x 표시 해 주세요.)

- [x] Feature
- [x] BugFix
- [x] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
<!-- 작업 내용을 작성합니다 -->
- RefeshToken으로 AccessToken 재발급(/api/tokens) GET 요청
- 재발급 API 테스트 작성, API 문서화 작성
- Exception 에러 모두 잡는 거 제거
- EntryPoint에서 NPE 발생 수정
- 로그아웃 시 토큰이 만료되면 그대로 로그아웃(오류 발생했음)
- api추가에 따른 구조 리팩토링(자주 사용하는 메소드 통합)
## 📚 작업 결과 (캡쳐한 사진이 있다면 올려주세요.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🫶 PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [ ] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [ ] Labels, Milestone이 Issue와 동일하게 적용되어 있습니다.
- [ ] Development에 PR 내용과 연결된 Issue를 등록했습니다.
