### PR TITLE
[Client][REFACTOR] 일지 작성 로딩 컴포넌트 구현, react-query로 요청부분 리팩토링

### DIFF
--- a/client/src/components/common/Header.tsx
+++ b/client/src/components/common/Header.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { ReactComponent as ArrowDownIcon } from '../../assets/icons/arrow-down.svg';
 import { ReactComponent as MypageIcon } from '../../assets/icons/mypage.svg';

--- a/client/src/pages/PlanDetailPage.tsx
+++ b/client/src/pages/PlanDetailPage.tsx
@@ -1,6 +1,3 @@
-import { Button } from '@/components';
-import useToast from '@/hooks/useToast';
-
 interface PlanDetailPageProps {}
 
 const PlanDetailPage = ({}: PlanDetailPageProps) => {

--- a/client/src/queries/RecordAPI.ts
+++ b/client/src/queries/RecordAPI.ts
@@ -2,17 +2,17 @@ import axios from 'axios';
 import BASE_URL from './BASE_URL';
 import instance from './axiosinstance';
 
-type RequestTypes = {
-  param: string;
-  formData?: FileList[];
+export type PostRecordTypes = {
+  param: number;
+  formData?: FormData;
   content?: string;
 };
 
 export default class RecordAPI {
-  readonly fileClient;
+  #fileClient;
 
   constructor() {
-    this.fileClient = axios.create({
+    this.#fileClient = axios.create({
       baseURL: BASE_URL,
       headers: {
         'Content-Type': 'multipart/form-data',
@@ -27,17 +27,17 @@ export default class RecordAPI {
   }
 
   async #postImages(param: number, formData: FormData) {
-    return this.fileClient.post(`${param}/img`, formData);
+    return this.#fileClient.post(`${param}/img`, formData);
   }
 
-  async onPostRecord(param: number, content: string, formData: FormData) {
-    return this.#postRecord(param, content).then((res) => {
+  async onPostRecord({ param, content, formData }: PostRecordTypes) {
+    return this.#postRecord(param, content!).then((res) => {
       const recordUrl = res.headers.location;
       if (res.status >= 400) {
         throw Error('일지 작성에 실패하였습니다.');
       }
 
-      return this.#postImages(recordUrl, formData)
+      return this.#postImages(recordUrl, formData!)
         .then((res) => {
           if (res.status >= 400) {
             throw Error('사진 전송에 실패하였습니다.');

--- a/client/src/queries/record/useCreateRecordMutation.tsx
+++ b/client/src/queries/record/useCreateRecordMutation.tsx
@@ -1,0 +1,27 @@
+import useToast from '@/hooks/useToast';
+import RecordAPI, { PostRecordTypes } from '@/queries/RecordAPI';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+const useCreateRecordMutation = () => {
+  const toast = useToast();
+  const recordAPI = new RecordAPI();
+  const createMutation = useMutation({
+    mutationFn: ({ param, content, formData }: PostRecordTypes) =>
+      recordAPI.onPostRecord({ param, content, formData }),
+    onSuccess() {
+      toast({ content: '일지가 정상적으로 작성 완료되었습니다.', type: 'success' });
+    },
+    onError: (error: AxiosError) => {
+      const message =
+        typeof error.response?.data === 'string'
+          ? error.response.data
+          : '일지 작성 실패하였습니다.';
+      toast({ content: message, type: 'warning' });
+    },
+  });
+
+  return createMutation;
+};
+
+export default useCreateRecordMutation;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- [Client/Server][FEAT] PR_제목 -->

## 📌 PR 타입 (해당하는 부분에 x 표시 해 주세요.)

- [ ] Feature
- [ ] BugFix
- [x] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
<!-- 작업 내용을 작성합니다 -->
일지 작성 요청 부분을 코드들을 `react-query`로 리팩토링하였습니다.

일지 작성 '확인' 버튼 컴포넌트에 로딩 컴포넌트를 추가하였습니다.

## 📚 작업 결과 (캡쳐한 사진이 있다면 올려주세요.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🫶 PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone이 Issue와 동일하게 적용되어 있습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.
