### PR TITLE
[Server][Fix] 이메일 반복 요청 오류 수정

### DIFF
--- a/server/src/main/java/com/server/domain/mail/service/AuthMailCodeService.java
+++ b/server/src/main/java/com/server/domain/mail/service/AuthMailCodeService.java
@@ -1,5 +1,7 @@
 package com.server.domain.mail.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,7 +17,9 @@ import lombok.RequiredArgsConstructor;
 public class AuthMailCodeService {
     private final AuthMailCodeRepository authMailCodeRepository;
 
-    public void saveAuthCode(String authCode, String email) {
+    public void saveOrUpdateAuthCode(String authCode, String email) {
+        Optional<AuthMailCode> authMailCode = authMailCodeRepository.findByEmail(email);
+        authMailCode.ifPresent(authMailCodeRepository::delete);
         authMailCodeRepository.save(AuthMailCode.builder().authCode(authCode).email(email).build());
     }
 

--- a/server/src/main/java/com/server/domain/mail/service/MailService.java
+++ b/server/src/main/java/com/server/domain/mail/service/MailService.java
@@ -44,7 +44,7 @@ public class MailService {
             mimeMessageHelper.setTo(email);
             mimeMessageHelper.setText(setContext(authCode, type), true);
             if(type.equals("signup") || type.equals("pw")){
-                authMailCodeService.saveAuthCode(authCode, email);
+                authMailCodeService.saveOrUpdateAuthCode(authCode, email);
             }
             mimeMessageHelper.setSubject(mailUtils.setSubject(type));
             javaMailSender.send(mimeMessage);


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- [Client/Server][FEAT] PR_제목 -->

## 📌 PR 타입 (해당하는 부분에 x 표시 해 주세요.)

- [ ] Feature
- [ ] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
<!-- 작업 내용을 작성합니다 -->
- 여러번 인증 요청을 했을 때 마지막 인증번호만 유효하다
- 기존에 있던 정보를 삭제하고 마지막 인증번호 데이터만 유효하게 변경
## 📚 작업 결과 (캡쳐한 사진이 있다면 올려주세요.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🫶 PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [ ] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [ ] Labels, Milestone이 Issue와 동일하게 적용되어 있습니다.
- [ ] Development에 PR 내용과 연결된 Issue를 등록했습니다.
