### PR TITLE
[Client][FIX] 일정 저장 후 내비게이트 경로, 페이지 재접속 시 검색 결과가 남아있는 버그 해결

### DIFF
--- a/client/src/components/map/SearchResult.tsx
+++ b/client/src/components/map/SearchResult.tsx
@@ -106,7 +106,6 @@ const SearchResult = ({
   useEffect(() => {
     if (data) {
       dispatch(setSearchPlaceResults(data.places));
-      onResetSearch();
     }
   }, [data]);
 

--- a/client/src/pages/PlanMapPage.tsx
+++ b/client/src/pages/PlanMapPage.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useBeforeUnload, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button } from '@/components';
 import Confirm from '@/components/common/Confirm';
@@ -74,11 +74,11 @@ const PlanMapPage = () => {
     }
   });
 
-  useBeforeUnload(
-    useCallback(() => {
+  useEffect(() => {
+    return () => {
       dispatch(setSearchPlaceResults([]));
-    }, [])
-  );
+    };
+  }, []);
 
   return (
     <div className="relative h-full w-full">

--- a/client/src/pages/PlanMapPage.tsx
+++ b/client/src/pages/PlanMapPage.tsx
@@ -50,7 +50,7 @@ const PlanMapPage = () => {
               primaryLabel="일정 목록으로 이동하기"
               secondaryLabel="이어서 작성하기"
               onClickPrimaryButton={() => {
-                navigate('/mypage');
+                navigate('/mypage/mytrip');
                 close();
               }}
               onClickSecondaryButton={close}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- [Client/Server][FEAT] PR_제목 -->

## 📌 PR 타입 (해당하는 부분에 x 표시 해 주세요.)

- [ ] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
<!-- 작업 내용을 작성합니다 -->
- 일정 저장 후 내비게이트 경로 마이페이지 -> 나의 일정 으로 변경
- 페이지 재접속 시 검색 결과 남아있는 버그 해결

## 📚 작업 결과 (캡쳐한 사진이 있다면 올려주세요.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🫶 PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone이 Issue와 동일하게 적용되어 있습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.
