### PR TITLE
[Client][FIX] 키워드 검색 시 변경된 위경도가 반영되지 않는 이슈 해결

### DIFF
--- a/client/src/components/map/SearchTools.tsx
+++ b/client/src/components/map/SearchTools.tsx
@@ -20,8 +20,8 @@ const SearchTools = ({ currentLng, currentLat }: Props) => {
   const [keyword, setKeyword] = useState<any>(null);
   const [categoryCode, setCategoryCode] = useState<CategoryGroupCode>('');
   const [searchCenterPosition, setSearchCenterPosition] = useState({
-    lat: currentLng,
-    lng: currentLat,
+    lat: currentLat,
+    lng: currentLng,
   });
 
   const dispatch = useDispatch();


### PR DESCRIPTION

<!-- PR 제목입니다. -->
<!-- [Client/Server][FEAT] PR_제목 -->

## 📌 PR 타입 (해당하는 부분에 x 표시 해 주세요.)

- [ ] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
<!-- 작업 내용을 작성합니다 -->
- 바뀐 페이지의 위경도를 받아오지 못하고 이전 좌표로 검색되는 이슈 해결

## 📚 작업 결과 (캡쳐한 사진이 있다면 올려주세요.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🫶 PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone이 Issue와 동일하게 적용되어 있습니다.
- [ ] Development에 PR 내용과 연결된 Issue를 등록했습니다.
