### PR TITLE
[Client][FIX] 편집 모드에서 장소 추가 시 사이드 패널에 반영되지 않는 버그 해결

### DIFF
--- a/client/src/components/schedule/accordion-content/DndContents.tsx
+++ b/client/src/components/schedule/accordion-content/DndContents.tsx
@@ -20,6 +20,10 @@ const DndContents = ({ contents, dayNumber }: DndContents) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    setPlaceList(contents);
+  }, [contents]);
+
+  useEffect(() => {
     if (isEditActionEnd) {
       dispatch(editSchedule({ dayNumber, schedule: placelist }));
       setIsEditActionEnd(false);


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- [Client/Server][FEAT] PR_제목 -->

## 📌 PR 타입 (해당하는 부분에 x 표시 해 주세요.)

- [ ] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
<!-- 작업 내용을 작성합니다 -->
- 일정 편집 모드(순서 변경 또는 장소 삭제)에서 일정 추가 시 사이드 패널에 반영되지 않는 버그 해결
  ```
  const DndContents = ({ contents, dayNumber }: DndContents) => {
    const [isEditActionEnd, setIsEditActionEnd] = useState(false);
    const [placelist, setPlaceList] = useState(contents);

    // ....  
  ```
  편집을 위해 contents(장소 목록)를 placelist라는 임시 상태 변수에 담아 사용하는데 장소 추가로 contents가 변경되었을 때 placelist에 반영되지 않고 있었음
  <img width="228" alt="스크린샷 2023-07-24 오전 11 05 44" src="https://github.com/codestates-seb/seb44_main_012/assets/69228045/39bb6516-574b-4915-93e0-f5224816e43d">

## 📚 작업 결과 (캡쳐한 사진이 있다면 올려주세요.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🫶 PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone이 Issue와 동일하게 적용되어 있습니다.
- [ ] Development에 PR 내용과 연결된 Issue를 등록했습니다.
