### PR TITLE
[Client][Bug] 일정 생성 시 하루 밀리는 버그 수정

### DIFF
--- a/client/src/pages/PlanPage.tsx
+++ b/client/src/pages/PlanPage.tsx
@@ -11,6 +11,7 @@ import useModal from '@/hooks/useModal';
 import usePlanMutation from '@/queries/plan/usePlanMutation';
 import { getFormatDateString, getTripPeriod, getTripTitleWithRegion } from '@/utils/date';
 import parsePlanId from '@/utils/parsePlanId';
+import syncDate from '@/utils/date/syncDate';
 
 interface PlanPageProps {}
 
@@ -59,13 +60,15 @@ const PlanPage = ({}: PlanPageProps) => {
   };
 
   const createPlan = () => {
+    console.log(`${startDate} ~ ${endDate}`);
+
     mutation
       .mutateAsync({
         title: getTripTitleWithRegion(selectedRegion!),
         region: selectedRegion!,
         content: null,
-        startDate: startDate!,
-        endDate: endDate!,
+        startDate: syncDate(startDate as Date),
+        endDate: syncDate(endDate as Date),
         places: null,
       })
       .then((res) => {
@@ -116,7 +119,10 @@ const PlanPage = ({}: PlanPageProps) => {
           <DatePicker
             placeholderText="오는 날 선택"
             selected={endDate}
-            onChange={(date) => setEndDate(date)}
+            onChange={(date) => {
+              console.log(date);
+              setEndDate(date);
+            }}
             minDate={startDate}
           />
           {startDate && endDate && (

--- a/client/src/utils/date/syncDate.ts
+++ b/client/src/utils/date/syncDate.ts
@@ -1,0 +1,7 @@
+const syncDate = (date: Date): Date => {
+  date?.setDate(date.getDate() + 1);
+
+  return date;
+};
+
+export default syncDate;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- [Client/Server][FEAT] PR_제목 -->

## 📌 PR 타입 (해당하는 부분에 x 표시 해 주세요.)

- [ ] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
<!-- 작업 내용을 작성합니다 -->
일정 생성 시 하루 밀리는 버그 수정입니다.

선택된 일정의 값을 콘솔 창으로 찍어보면 아래와 같이 정상적으로 나타나며 한국 표준시로 잘 나타납니다.

![image](https://github.com/codestates-seb/seb44_main_012/assets/48381447/3fb52c09-01c7-45e6-9696-bef027bd4a6a)

하지만 실제 네트워크에 담겨져 보내지는 데이터는 하루 정도 밀리며 표준시는 UTC로 되어 있습니다.

![image](https://github.com/codestates-seb/seb44_main_012/assets/48381447/eb556ffb-5f55-49be-ba40-2f6fb84e12d8)

원인을 알아본 바 요청을 보낼 때 json의 직렬화하는 과정에서 타임존이 변경되는 이슈가 있어 발생된 에러였습니다.

https://stackoverflow.com/a/15171030
> JavaScript's Date object tracks time in UTC internally, but typically accepts input and produces output in the local time of the computer it's running on. It has very few facilities for working with time in other time zones.

해결 방법은 현재 로컬로 Re-Parsing을 하거나, UTC 타임존으로 포멧 변경, Epoch Shifting 방법이 있다고 하네요...

지금 커밋은 단순히 하루를 더 해줘서 요청을 보내 해결하였습니다.

```
// utils/date/syncDate.ts
const syncDate = (date: Date): Date => {
  date?.setDate(date.getDate() + 1);

  return date;
};

export default syncDate;
```


## 📚 작업 결과 (캡쳐한 사진이 있다면 올려주세요.)
<!-- 없다면 적지 않으셔도 됩니다. -->
- syncDate 함수 적용 후 요청 페이로드 
![image](https://github.com/codestates-seb/seb44_main_012/assets/48381447/703df94a-e54b-4276-8781-19e3d50c1769)


## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🫶 PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone이 Issue와 동일하게 적용되어 있습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.
