### PR TITLE
[Client][BugFix] 나의 일정에서 일정 카드 내 빈 공백 클릭 시 일정 이름 변경 모달창 뜨는 현상 fix

### DIFF
--- a/client/src/components/page-components/mytrip/GridItem.tsx
+++ b/client/src/components/page-components/mytrip/GridItem.tsx
@@ -15,7 +15,7 @@ type Props = {
 const maxTitleLength = 30;
 
 const GridItem = ({ id, title, content, editable }: Props) => {
-  const [isEdit, setIsEdit] = useState(!editable);
+  const [isEdit, setIsEdit] = useState(false);
   const [text, setText] = useState(
     editable && (content as String).length === 0
       ? '여행의 이름을 지어주세요~!'


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- [Client/Server][FEAT] PR_제목 -->

## 📌 PR 타입 (해당하는 부분에 x 표시 해 주세요.)

- [ ] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
<!-- 작업 내용을 작성합니다 -->
나의 일정에서 일정 카드 내 빈 공백 클릭 시 일정 이름 변경 모달창 뜨는 현상 fix

## 📚 작업 결과 (캡쳐한 사진이 있다면 올려주세요.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🫶 PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [ ] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [ ] Labels, Milestone이 Issue와 동일하게 적용되어 있습니다.
- [ ] Development에 PR 내용과 연결된 Issue를 등록했습니다.
