### PR TITLE
[Client][BugFix] 나의 일정 페이지에서 일정 수정 후 '여행장소' 리렌더링 되지 않은 현상 수정

### DIFF
--- a/client/src/pages/MyTripPage.tsx
+++ b/client/src/pages/MyTripPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus-circle.svg';
 import { Button, HeadingParagraph, Paragraph, SortingToolbar } from '@/components';
@@ -11,7 +11,7 @@ const MyTripPage = () => {
   const auth = useAuthRedirect();
   if (auth.isRedirect) return auth.naviComponent;
 
-  const { data, isLoading, error } = useMyTripQuery();
+  const { data, isLoading, isFetching, error, refetch } = useMyTripQuery();
 
   return (
     <div className="flex h-auto w-full flex-col pb-20">
@@ -25,7 +25,7 @@ const MyTripPage = () => {
         }`}
       >
         {isLoading && <LoadingSpinner />}
-        {!isLoading && data!.length > 0 ? (
+        {!isFetching && !isLoading && data!.length > 0 ? (
           data!.map((item) => <MyTripCard key={item.scheduleId} {...item} />)
         ) : (
           <Link to="/plan" className=" flex flex-col items-center justify-center gap-2">

--- a/client/src/pages/PlanMapPage.tsx
+++ b/client/src/pages/PlanMapPage.tsx
@@ -16,6 +16,7 @@ import { setIsStale } from '@/redux/slices/scheduleSlice';
 import { RootState } from '@/redux/store';
 import { getRegionCenterLat, getRegionCenterLng } from '@/utils/map';
 import LoadingPage from './LoadingPage';
+import { useQueryClient } from '@tanstack/react-query';
 
 const PlanMapPage = () => {
   const { id } = useParams();
@@ -24,6 +25,8 @@ const PlanMapPage = () => {
 
   const navigate = useNavigate();
   const toast = useToast();
+  const queryClient = useQueryClient();
+
   const [openModal] = useModal();
   const [mapLevel, setMapLevel] = useState(8);
   const [centerPosition, setCenterPosition] = useState({


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- [Client/Server][FEAT] PR_제목 -->

## 📌 PR 타입 (해당하는 부분에 x 표시 해 주세요.)

- [ ] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
<!-- 작업 내용을 작성합니다 -->
나의 일정 페이지에서 일정 수정 후 '여행장소' 리렌더링 되지 않은 현상 수정입니다.
![placeSize](https://github.com/codestates-seb/seb44_main_012/assets/48381447/1ca24ce8-284e-4cb9-8bdd-73d4697b1ec3)

지현님이 해결해줌 

지현 : 페칭되서 새로운 것을 쓸 수 있는 시간이랑, 캐싱된 것을 사용하는 시간이 어긋나서 캐싱된 것을 먼저 써버려서 데이터가 최신화가 됐음에도 리렌더링이 되지 않는 느낌(?)

## 📚 작업 결과 (캡쳐한 사진이 있다면 올려주세요.)
<!-- 없다면 적지 않으셔도 됩니다. -->

- `isFetching` 조건을 추가로 페칭이 되면 해당 컴포넌트를 리렌더링하게 수정
```jsx
{!isFetching && !isLoading && data!.length > 0 ? (
  data!.map((item) => <MyTripCard key={item.scheduleId} {...item} />)
) : (
  <Link to="/plan" className=" flex flex-col items-center justify-center gap-2">
    <Paragraph>최근 여행 일정이 없습니다. 여행 계획해볼까요?</Paragraph>
    <Paragraph className=" flex items-center justify-center">
      <Button hovercolor={'default'} className="mr-2 p-0">
        <PlusIcon width={18} height={18} />
      </Button>
      여행 일정 생성하러가기
    </Paragraph>
  </Link>
)}
```
![placeSize2](https://github.com/codestates-seb/seb44_main_012/assets/48381447/398a927d-1aa1-4ddf-86a1-4dc33a0b13b2)



## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
<!-- 없다면 적지 않으셔도 됩니다. -->

## 🫶 PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
- [x] Labels, Milestone이 Issue와 동일하게 적용되어 있습니다.
- [x] Development에 PR 내용과 연결된 Issue를 등록했습니다.
